### PR TITLE
Add garbage collector for badger

### DIFF
--- a/server/raft_fsm.go
+++ b/server/raft_fsm.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -38,6 +39,10 @@ func NewRaftFSM(path string, logger *zap.Logger) (*RaftFSM, error) {
 		logger.Error("failed to create key value store", zap.String("path", path), zap.Error(err))
 		return nil, err
 	}
+
+	// TODO: Context should be passed down to allow for cascade cancellation.
+	// TODO: GC should have its own flags for both the interval (--gc-interval=5m) and ratio (--gc-discard-ratio=0.5).
+	kvs.RunGC(context.Background(), 5*time.Minute, 0.5)
 
 	return &RaftFSM{
 		logger:   logger,


### PR DESCRIPTION
There is a very important feature missing from BagderDB: the garbage collector for database vlog files.
We have experienced database outage due to "no space left on device" errors, an internal investigation led to the conclusion that the database vlogs were increasing at each restart and never collected, ultimately leading to the disk being completely filled with vlogs.

This PR introduces a garbage collector routine as described in https://dgraph.io/docs/badger/get-started/#garbage-collection

If merged this PR it can be further extended by add 2 new flags `--gc-interval=5m --gc-discard-ratio=0.5` as well as a context that can be used to cancel the garbage collector.